### PR TITLE
Ticket 20 article id comments pagination

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -317,6 +317,69 @@ describe("GET /api/articles/:article_id/comments", () => {
     });
 
   });
+  describe("limit query", () => {
+    test("200: responds with 5 comments", () => {
+    return request(app).get(`/api/articles/1/comments?limit=5`)
+    .expect(200)
+    .then(({body}) => {
+      expect(body.comments.length).toBe(5)
+      });
+    });
+    test("200: responds with 10 comments if limit is declared but undefined", () => {
+    return request(app).get(`/api/articles/1/comments?limit`)
+    .expect(200)
+    .then(({body}) => {
+      expect(body.comments.length).toBe(10)
+      });
+    });
+    test("200: responds with 10 comments if limit is declared but invalid", () => {
+      return request(app).get(`/api/articles/1/comments?limit=jkl&p=1`)
+      .expect(200)
+      .then(({body}) => {
+        expect(body.comments.length).toBe(10)
+        });
+      });
+    test("200: responds with default behaviour if limit < 0", () => {
+      return request(app).get(`/api/aticles/1/comments?limit=-4`)
+    })
+    });
+  describe("p query", () => {
+    test("200: returns defaut behaviour without the limit query", () => {
+      return request(app).get(`/api/articles/1/comments?p=2`)
+        .expect(200)
+        .then(({body}) => {
+          expect(body.comments.length).toBe(11);
+      });
+    });
+    test("200: reduces the number returned from the limit when running out of comments", () => {
+      return request(app).get(`/api/articles/1/comments?limit=5&p=3`)
+        .expect(200)
+        .then(({body}) => {
+          expect(body.comments.length).toBe(1);
+        });
+    });
+    test("200: returns an empty array when the page number exceeds the number of comments", () => {
+      return request(app).get(`/api/articles/1/comments?limit=10&p=10`)
+        .expect(200)
+        .then(({body}) => {
+          expect(body.comments.length).toBe(0);
+        });
+    });
+    test("200: defaults to page 1 if given an invalid p = jkl", () => {
+        return request(app).get(`/api/articles/1/comments?limit=10&p=jkl`)
+        .expect(200)
+        .then(({body}) => {
+          expect(body.comments.length).toBe(10);
+        });
+    });
+    test("200: responds with default pg number if p < 0", () => {
+      return request(app).get(`/api/articles/1/comments?limit=10&p=-1`)
+      .expect(200)
+      .then(({body}) => {
+        expect(body.comments.length).toBe(10);
+      });
+    });
+  });
 });
 
 describe("GET /api/users", () => {

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,11 +1,12 @@
 const {
   convertTimestampToDate,
   formatComments,
-  articleLookup
+  articleLookup,
 } = require("../db/seeds/utils");
 
 const {
-  checkExists
+  checkExists,
+  paginationSql
 } = require("../server/utils");
 
 const db = require("../db/connection");
@@ -173,5 +174,61 @@ describe("checkExists", () => {
       expect(res.status).toBe(404);
       expect(res.msg).toBe("Resource not found");
     })
+  });
+});
+
+describe("paginationSql", () => {
+  describe("LIMIT", () => {
+    test("returns LIMIT = limit", () => {
+      const limit = 20;
+      const string = paginationSql(limit)
+      expect(string).toBe("LIMIT '20' OFFSET '0' ")
+    });
+    test("positive rational numbers", () => {
+      const limit = 5.4;
+      const string = paginationSql(limit);
+      expect(string).toBe("LIMIT '5' OFFSET '0' ");
+    });
+    test("returns LIMIT 10 when passed LIMIT < 0.51", () => {
+      const limit = 0.5
+      const string = paginationSql(limit)
+      expect(string).toBe("LIMIT '10' OFFSET '0' ")
+    });
+    test("returns LIMIT 10 when passed LIMIT = jkl", () => {
+      const pg_number = 1;
+      const limit = "jkl";
+      const string = paginationSql(limit)
+      expect(string).toBe("LIMIT '10' OFFSET '0' ")
+    });
+    test("returns '' when limit = undefined", () => {
+      const string = paginationSql();
+      expect(string).toBe("");
+    });
+  });
+  describe("pg_number", () => {
+    test("returns OFFSET as multiple of pg_number and limit", () => {
+      const pg_number = 3;
+      const limit = 5;
+      const string = paginationSql(limit,pg_number);
+      expect(string).toBe("LIMIT '5' OFFSET '10' ");
+    });
+    test("positive rational numbers", () => {
+      const pg_number = 3.4;
+      const limit = 5;
+      const string = paginationSql(limit,pg_number);
+      expect(string).toBe("LIMIT '5' OFFSET '10' ");
+    });
+    test("returns page number 1/ OFFSET = 0 when pg_number < 0", () => {
+      const pg_number = -1;
+      const limit = 5
+      const string = paginationSql(limit,pg_number)
+      expect(string).toBe("LIMIT '5' OFFSET '0' ")
+    });
+    test("returns OFFSET 0 when passed pg_number = jkl", () => {
+      const pg_number = "jkl";
+      const limit = 5
+      const string = paginationSql(limit,pg_number)
+      expect(string).toBe("LIMIT '5' OFFSET '0' ")
+    });
   });
 });

--- a/server/controllers/comments.controllers.js
+++ b/server/controllers/comments.controllers.js
@@ -7,8 +7,7 @@ const {
 
 exports.getArticleComments = async (request, response, next) => {
     try {
-        const { article_id } = request.params;
-        const comments = await fetchArticleComments(article_id);
+        const comments = await fetchArticleComments(request.params, request.query);
         response.status(200).send({ comments });
         
     } catch (error) {

--- a/server/models/comments.models.js
+++ b/server/models/comments.models.js
@@ -1,9 +1,19 @@
 const db = require("../../db/connection")
-const {checkExists} = require("../utils")
+const {
+    checkExists, 
+    paginationSql
+} = require("../utils");
+const format = require("pg-format");
 
-exports.fetchArticleComments = async (article_id) => {
-    await checkExists("articles", "article_id", article_id)
-    return (await db.query(`SELECT * FROM comments WHERE comments.article_id = $1`,[article_id])).rows;
+exports.fetchArticleComments = async (params, query) => {
+    const { article_id } = params;
+    const { limit, p } = query;
+    await checkExists("articles", "article_id", article_id);
+    let queryStr = format(`SELECT * FROM comments WHERE comments.article_id = %L`, article_id);
+
+    queryStr += paginationSql(limit, p);
+
+    return (await db.query(queryStr)).rows;
     
 };
 

--- a/server/utils.js
+++ b/server/utils.js
@@ -12,3 +12,20 @@ exports.checkExists = async (table, column, value) => {
 
     return true;
 };
+
+exports.paginationSql = ( limit, pgNumber ) => {
+    let paginationStr = '';
+    if (limit || limit === '') {
+        let offset = 0;
+        if(!isNaN(Number(pgNumber)) && !(pgNumber === '') && pgNumber >= 1) {
+            offset = Math.round(pgNumber) - 1;
+        };
+
+        if (isNaN(Number(limit)) || limit === ''|| limit <= 0.51) {
+            paginationStr += format(`LIMIT '10' OFFSET %L `,offset * 10);
+        } else {
+            paginationStr += format(`LIMIT %L OFFSET %L `, Math.round(limit), offset * Math.round(limit));
+        };
+    };
+    return paginationStr;
+};


### PR DESCRIPTION
# Ticket 20

## tests
### limit query
- 200 limit =5
- 200 limit =
- 200 limit = jkl
- 200 limit <= 0.51
### p query
- 200 no limit p = 1
- 200 limit = 10 p = 2 comments.length = 1
- 200 limit= 100 p = 99999
- 200 limit = 10 p = jkl
No 400, fail gracefully

## util tests
- LIMIT
- LIMIT = 3.456
- LIMIT = <0.51
- LIMIT = jkl
- LIMIT = undefined
- pg_number = INT
- pg_number = 3.456
- pg_number = -1
- pg_number = jkl

## utils
paginationSql

## api-comments-router.js
no change

## articles.controllers
getArticleComments{return {comments}}

## users.models
fetchArticleComments refactored paginationSql